### PR TITLE
Fix display of results when no address given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased](https://github.com/Amsterdam/bereikbaarheid-frontend/compare/v2.3.0...HEAD)
 
+### Fixed
+- Prohibitory signs: display results when no address given
+
 
 ## [v2.3.0 - 2023-02-17](https://github.com/Amsterdam/bereikbaarheid-frontend/compare/v2.2.1...v2.3.0)
 

--- a/src/pages/ProhibitorySigns/components/ScenarioDisplay/Result.tsx
+++ b/src/pages/ProhibitorySigns/components/ScenarioDisplay/Result.tsx
@@ -46,7 +46,7 @@ const ScenarioDisplayResult = () => {
   const permitsByLocation = usePermitsByLocation()
   const [showRvvDetails, setShowRvvDetails] = useState(false)
 
-  if (permitsByLocation.isLoading) {
+  if (permitsByLocation.isInitialLoading) {
     return <LoadingSpinner />
   }
 

--- a/src/pages/ProhibitorySigns/hooks/usePermitsByLocation.ts
+++ b/src/pages/ProhibitorySigns/hooks/usePermitsByLocation.ts
@@ -41,6 +41,6 @@ export const usePermitsByLocation = () => {
 
   return {
     data: queryResult.data,
-    isLoading: queryResult.isLoading,
+    isInitialLoading: queryResult.isInitialLoading,
   }
 }


### PR DESCRIPTION
This PR fixes the display of results when no address given during the wizard on the Prohibitory Signs page.