### PR TITLE
TOUR-47: Uses API root in download URL

### DIFF
--- a/src/api/touringcar/download/index.ts
+++ b/src/api/touringcar/download/index.ts
@@ -1,6 +1,6 @@
 import config from 'config'
 
-import api from '../../data.amsterdam'
+import { api } from '../../bereikbaarheid/index'
 
 const ENDPOINT = `${config.API_ROOT}/touringcar/downloads/csv`
 

--- a/src/api/touringcar/download/index.ts
+++ b/src/api/touringcar/download/index.ts
@@ -1,6 +1,8 @@
+import config from 'config'
+
 import api from '../../data.amsterdam'
 
-const ENDPOINT = 'v1/touringcar/downloads/csv'
+const ENDPOINT = `${config.API_ROOT}/touringcar/downloads/csv`
 
 function getTouringcarCsv(signal?: AbortSignal): Promise<string> {
   return api.get(ENDPOINT, { signal }).then(response => response.data)

--- a/src/pages/DataSources/__snapshots__/DataSourcesPage.test.tsx.snap
+++ b/src/pages/DataSources/__snapshots__/DataSourcesPage.test.tsx.snap
@@ -823,7 +823,7 @@ FAQ en contactgegevens"
               >
                 <a
                   class="sc-jEACwC gTqerM sc-jxOSlx lBYNR"
-                  href="https://api.data.amsterdam.nl/v1/api/v1/touringcar/downloads/csv"
+                  href="api/v1/touringcar/downloads/csv"
                   target="_blank"
                 >
                   <span
@@ -1758,7 +1758,7 @@ FAQ en contactgegevens"
             >
               <a
                 class="sc-jEACwC gTqerM sc-jxOSlx lBYNR"
-                href="https://api.data.amsterdam.nl/v1/api/v1/touringcar/downloads/csv"
+                href="api/v1/touringcar/downloads/csv"
                 target="_blank"
               >
                 <span

--- a/src/pages/DataSources/__snapshots__/DataSourcesPage.test.tsx.snap
+++ b/src/pages/DataSources/__snapshots__/DataSourcesPage.test.tsx.snap
@@ -823,7 +823,7 @@ FAQ en contactgegevens"
               >
                 <a
                   class="sc-jEACwC gTqerM sc-jxOSlx lBYNR"
-                  href="https://api.data.amsterdam.nl/v1/v1/touringcar/downloads/csv"
+                  href="https://api.data.amsterdam.nl/v1/api/v1/touringcar/downloads/csv"
                   target="_blank"
                 >
                   <span
@@ -1758,7 +1758,7 @@ FAQ en contactgegevens"
             >
               <a
                 class="sc-jEACwC gTqerM sc-jxOSlx lBYNR"
-                href="https://api.data.amsterdam.nl/v1/v1/touringcar/downloads/csv"
+                href="https://api.data.amsterdam.nl/v1/api/v1/touringcar/downloads/csv"
                 target="_blank"
               >
                 <span

--- a/src/pages/Touringcar/__snapshots__/TouringcarPage.test.tsx.snap
+++ b/src/pages/Touringcar/__snapshots__/TouringcarPage.test.tsx.snap
@@ -880,7 +880,7 @@ FAQ en contactgegevens"
                           >
                             <a
                               class="sc-jEACwC gTqerM sc-jxOSlx lBYNR"
-                              href="https://api.data.amsterdam.nl/v1/api/v1/touringcar/downloads/csv"
+                              href="api/v1/touringcar/downloads/csv"
                               target="_blank"
                             >
                               <span
@@ -2240,7 +2240,7 @@ FAQ en contactgegevens"
                         >
                           <a
                             class="sc-jEACwC gTqerM sc-jxOSlx lBYNR"
-                            href="https://api.data.amsterdam.nl/v1/api/v1/touringcar/downloads/csv"
+                            href="api/v1/touringcar/downloads/csv"
                             target="_blank"
                           >
                             <span

--- a/src/pages/Touringcar/__snapshots__/TouringcarPage.test.tsx.snap
+++ b/src/pages/Touringcar/__snapshots__/TouringcarPage.test.tsx.snap
@@ -880,7 +880,7 @@ FAQ en contactgegevens"
                           >
                             <a
                               class="sc-jEACwC gTqerM sc-jxOSlx lBYNR"
-                              href="https://api.data.amsterdam.nl/v1/v1/touringcar/downloads/csv"
+                              href="https://api.data.amsterdam.nl/v1/api/v1/touringcar/downloads/csv"
                               target="_blank"
                             >
                               <span
@@ -2240,7 +2240,7 @@ FAQ en contactgegevens"
                         >
                           <a
                             class="sc-jEACwC gTqerM sc-jxOSlx lBYNR"
-                            href="https://api.data.amsterdam.nl/v1/v1/touringcar/downloads/csv"
+                            href="https://api.data.amsterdam.nl/v1/api/v1/touringcar/downloads/csv"
                             target="_blank"
                           >
                             <span

--- a/src/pages/Touringcar/components/Messages/__snapshots__/Messages.test.tsx.snap
+++ b/src/pages/Touringcar/components/Messages/__snapshots__/Messages.test.tsx.snap
@@ -880,7 +880,7 @@ FAQ en contactgegevens"
                           >
                             <a
                               class="sc-jEACwC gTqerM sc-jxOSlx lBYNR"
-                              href="https://api.data.amsterdam.nl/v1/api/v1/touringcar/downloads/csv"
+                              href="api/v1/touringcar/downloads/csv"
                               target="_blank"
                             >
                               <span
@@ -2240,7 +2240,7 @@ FAQ en contactgegevens"
                         >
                           <a
                             class="sc-jEACwC gTqerM sc-jxOSlx lBYNR"
-                            href="https://api.data.amsterdam.nl/v1/api/v1/touringcar/downloads/csv"
+                            href="api/v1/touringcar/downloads/csv"
                             target="_blank"
                           >
                             <span

--- a/src/pages/Touringcar/components/Messages/__snapshots__/Messages.test.tsx.snap
+++ b/src/pages/Touringcar/components/Messages/__snapshots__/Messages.test.tsx.snap
@@ -880,7 +880,7 @@ FAQ en contactgegevens"
                           >
                             <a
                               class="sc-jEACwC gTqerM sc-jxOSlx lBYNR"
-                              href="https://api.data.amsterdam.nl/v1/v1/touringcar/downloads/csv"
+                              href="https://api.data.amsterdam.nl/v1/api/v1/touringcar/downloads/csv"
                               target="_blank"
                             >
                               <span
@@ -2240,7 +2240,7 @@ FAQ en contactgegevens"
                         >
                           <a
                             class="sc-jEACwC gTqerM sc-jxOSlx lBYNR"
-                            href="https://api.data.amsterdam.nl/v1/v1/touringcar/downloads/csv"
+                            href="https://api.data.amsterdam.nl/v1/api/v1/touringcar/downloads/csv"
                             target="_blank"
                           >
                             <span


### PR DESCRIPTION
Fixes 404 resulting from malformed CSV download URL  